### PR TITLE
Add date calculation for donation eligibility

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,14 @@ const allData = [...dataA, ...dataB, ...dataC, ...dataD, ...dataE];
 
 function App() {
   const [query, setQuery] = useState('');
+  const [eventDate, setEventDate] = useState('');
+
+  const formatDate = date => {
+    const yyyy = date.getFullYear();
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+    return `${yyyy}년${mm}월${dd}일`;
+  };
 
   const results = useMemo(() => {
     if (!query) return [];
@@ -33,12 +41,33 @@ function App() {
         value={query}
         onChange={e => setQuery(e.target.value)}
       />
+      <input
+        className="date-input"
+        type="date"
+        aria-label="이벤트 날짜"
+        value={eventDate}
+        onChange={e => setEventDate(e.target.value)}
+      />
       <ul className="result-list">
-        {results.map((item, index) => (
-          <li key={index} className="result-item">
-            <strong>{item.name}</strong> ({item.type}) - {item.restriction}
-          </li>
-        ))}
+        {results.map((item, index) => {
+          const period = item.restriction_period_days;
+          let message;
+          if (period < 0) {
+            message = '헌혈 불가';
+          } else if (period === 0) {
+            message = '즉시 가능';
+          } else {
+            const base = eventDate ? new Date(eventDate) : new Date();
+            base.setDate(base.getDate() + period);
+            message = formatDate(base);
+          }
+          return (
+            <li key={index} className="result-item">
+              <strong>{item.name}</strong> ({item.type}) - {item.restriction}
+              <div className="eligible-date">{message}</div>
+            </li>
+          );
+        })}
         {query && results.length === 0 && (
           <li className="no-result">검색 결과가 없습니다.</li>
         )}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -10,3 +10,26 @@ test('검색어 입력 시 해당 제한 조건이 표시된다', async () => {
     screen.getByText(/감염 이력 있는 경우 영구 헌혈 금지/i)
   ).toBeInTheDocument();
 });
+
+test('양성 제한 기간이 있는 항목은 날짜를 계산한다', async () => {
+  render(<App />);
+  const queryInput = screen.getByPlaceholderText(/검색어를 입력하세요/i);
+  const dateInput = screen.getByLabelText('이벤트 날짜');
+  await userEvent.type(dateInput, '2024-01-01');
+  await userEvent.type(queryInput, 'Doxy');
+  expect(screen.getByText('2024년01월08일')).toBeInTheDocument();
+});
+
+test('음수 제한 기간은 헌혈 불가로 표시한다', async () => {
+  render(<App />);
+  const input = screen.getByPlaceholderText(/검색어를 입력하세요/i);
+  await userEvent.type(input, 'HCV');
+  expect(screen.getByText('헌혈 불가')).toBeInTheDocument();
+});
+
+test('제한 기간이 0이면 즉시 가능으로 표시한다', async () => {
+  render(<App />);
+  const input = screen.getByPlaceholderText(/검색어를 입력하세요/i);
+  await userEvent.type(input, '코로나19 백신');
+  expect(screen.getByText('즉시 가능')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- compute next donation date for positive restriction periods
- allow entering an event date (default to today)
- show `헌혈 불가` or `즉시 가능` when applicable
- test donation date calculation logic

## Testing
- `npm test --silent --runTestsByPath src/App.test.js` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688337e56358832bbc5bf0d3b14b74d3