### PR TITLE
Fix closing brace in results map

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -87,7 +87,7 @@ function App() {
               <div className="eligible-date">{message}</div>
             </li>
           );
-        })}
+        })
         {query && results.length === 0 && (
           <li className="no-result">검색 결과가 없습니다.</li>
         )}


### PR DESCRIPTION
## Summary
- fix closing brace in `results.map` block

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68833ddd7a0c832bb43f3a441973eb20