### PR TITLE
Handle restriction types in App

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -106,24 +106,34 @@ function App() {
         <ul className="result-list list-none mt-5 flex flex-col items-center space-y-3">
           {results.map((item) => {
             const period = item.restriction_period_days;
+            const type = item.restriction_type;
+
             let periodText;
-            if (period < 0) {
+            if (type === 'permanent') {
               periodText = '영구 금지';
+            } else if (type === 'conditional') {
+              periodText = '조건부 금지';
             } else if (period === 0) {
               periodText = '금지 기간 없음';
-            } else {
+            } else if (period > 0) {
               periodText = `금지 기간: ${period}일`;
+            } else {
+              periodText = '영구 금지';
             }
 
             let message;
-            if (period < 0) {
+            if (type === 'permanent') {
               message = '헌혈 불가';
+            } else if (type === 'conditional') {
+              message = '완치 후 가능';
             } else if (period === 0) {
               message = '즉시 가능';
-            } else {
+            } else if (period > 0) {
               const base = eventDate ? new Date(eventDate) : new Date();
               base.setDate(base.getDate() + period);
               message = formatDate(base);
+            } else {
+              message = '헌혈 불가';
             }
 
             return (

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -23,13 +23,22 @@ test('양성 제한 기간이 있는 항목은 기간 텍스트와 날짜를 계
   expect(screen.getByText('2024년01월08일')).toBeInTheDocument();
 });
 
-// 음수 제한 기간은 영구 금지와 헌혈 불가로 표시한다
-test('음수 제한 기간은 영구 금지와 헌혈 불가로 표시한다', async () => {
+// 영구 제한 타입은 영구 금지와 헌혈 불가로 표시한다
+test('영구 제한 타입은 영구 금지와 헌혈 불가로 표시한다', async () => {
   render(<App />);
   const input = screen.getByPlaceholderText(/검색어를 입력하세요/i);
   await userEvent.type(input, 'HCV');
   expect(screen.getByText('영구 금지')).toBeInTheDocument();
   expect(screen.getByText('헌혈 불가')).toBeInTheDocument();
+});
+
+// 조건부 제한 타입은 조건부 금지와 완치 후 가능으로 표시한다
+test('조건부 제한 타입은 조건부 금지와 완치 후 가능으로 표시한다', async () => {
+  render(<App />);
+  const input = screen.getByPlaceholderText(/검색어를 입력하세요/i);
+  await userEvent.type(input, '감기');
+  expect(screen.getByText('조건부 금지')).toBeInTheDocument();
+  expect(screen.getByText('완치 후 가능')).toBeInTheDocument();
 });
 
 // 제한 기간이 0이면 금지 기간 없음과 즉시 가능으로 표시한다


### PR DESCRIPTION
## Summary
- show restriction text for `restriction_type`
- adjust period and message output
- update tests for new conditionals

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883534f48a8832ba0eeb62a1a6b83dd