### PR TITLE
Add category filtering

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ const allData = [
 function App() {
   const [query, setQuery] = useState('');
   const [eventDate, setEventDate] = useState('');
+  const [filterType, setFilterType] = useState('');
 
   const formatDate = (date) => {
     const yyyy = date.getFullYear();
@@ -60,16 +61,18 @@ function App() {
   };
 
   const results = useMemo(() => {
-    if (!query) return [];
+    if (!query && !filterType) return [];
     const lower = query.toLowerCase();
     return allData.filter((item) => {
+      if (filterType && item.type !== filterType) return false;
+      if (!query) return true;
       const nameMatch = item.name.toLowerCase().includes(lower);
       const aliasMatch = (item.aliases || []).some((alias) =>
         alias.toLowerCase().includes(lower)
       );
       return nameMatch || aliasMatch;
     });
-  }, [query]);
+  }, [query, filterType]);
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>
@@ -93,6 +96,20 @@ function App() {
             onChange={(e) => setQuery(e.target.value)}
           />
         </div>
+
+        <select
+          aria-label="카테고리 필터"
+          value={filterType}
+          onChange={(e) => setFilterType(e.target.value)}
+          className="input-style"
+        >
+          <option value="">전체</option>
+          <option value="질병">질병</option>
+          <option value="지역">지역</option>
+          <option value="약물">약물</option>
+          <option value="백신">백신</option>
+          <option value="기타">기타</option>
+        </select>
 
         <input
           className="date-input input-style"

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -71,3 +71,10 @@ test('테마 토글 버튼 클릭 시 document 클래스가 변경된다', async
   await userEvent.click(button);
   expect(document.documentElement.classList.contains('dark')).toBe(false);
 });
+
+test('카테고리 필터 선택 시 해당 항목이 표시된다', async () => {
+  render(<App />);
+  const select = screen.getByLabelText(/카테고리 필터/i);
+  await userEvent.selectOptions(select, '질병');
+  expect(screen.getByText('C형 간염')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- include a new filterType state for selecting data type
- allow filtering search results by the selected category
- add dropdown UI for choosing the category
- show items when a category is chosen without any query
- expand tests for the new category filter

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68835489c16c832ba56e6e6888dbcc6f