### PR TITLE
Remove date input and state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,6 @@ const allData = [
 
 function App() {
   const [query, setQuery] = useState('');
-  const [eventDate, setEventDate] = useState('');
 
   const formatDate = (date) => {
     const yyyy = date.getFullYear();
@@ -94,13 +93,6 @@ function App() {
           />
         </div>
 
-        <input
-          className="date-input input-style"
-          type="date"
-          aria-label="이벤트 날짜"
-          value={eventDate}
-          onChange={(e) => setEventDate(e.target.value)}
-        />
 
         <ul className="result-list list-none mt-5 flex flex-col items-center space-y-3">
           {results.map((item) => {
@@ -128,7 +120,7 @@ function App() {
             } else if (period === 0) {
               message = '즉시 가능';
             } else if (period > 0) {
-              const base = eventDate ? new Date(eventDate) : new Date();
+              const base = new Date();
               base.setDate(base.getDate() + period);
               message = formatDate(base);
             } else {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -12,17 +12,6 @@ test('검색어 입력 시 해당 제한 조건이 표시된다', async () => {
   ).toBeInTheDocument();
 });
 
-// 양성 제한 기간이 있는 항목은 기간 텍스트와 날짜를 계산한다
-test('양성 제한 기간이 있는 항목은 기간 텍스트와 날짜를 계산한다', async () => {
-  render(<App />);
-  const queryInput = screen.getByPlaceholderText(/검색어를 입력하세요/i);
-  const dateInput = screen.getByLabelText('이벤트 날짜');
-  await userEvent.type(dateInput, '2024-01-01');
-  await userEvent.type(queryInput, 'Doxy');
-  expect(screen.getByText('금지 기간: 7일')).toBeInTheDocument();
-  expect(screen.getByText('2024년01월08일')).toBeInTheDocument();
-});
-
 // 영구 제한 타입은 영구 금지와 헌혈 불가로 표시한다
 test('영구 제한 타입은 영구 금지와 헌혈 불가로 표시한다', async () => {
   render(<App />);


### PR DESCRIPTION
## Summary
- remove event date input UI and state
- base date for restriction calculations is always `new Date()`
- drop test referencing removed date input

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883548af008832bb4c103064696a9f0