### PR TITLE
Fix dynamic coloring for eligible dates

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -145,7 +145,9 @@ function App() {
               message = '헌혈 불가';
             }
 
-            const colorClass = message === '헌혈 불가' ? 'text-red-500' : 'text-green-500';
+            const colorClass = message === '헌혈 불가'
+              ? 'text-red-500 dark:text-red-400'
+              : 'text-green-500 dark:text-green-400';
 
             return (
               <li key={item.id} className="result-item">

--- a/src/index.css
+++ b/src/index.css
@@ -39,5 +39,5 @@ html.dark {
   @apply text-sm text-gray-700 dark:text-gray-300;
 }
 .eligible-date {
-  @apply text-sm text-primary;
+  @apply text-sm;
 }


### PR DESCRIPTION
## Summary
- allow `eligible-date` class to inherit dynamic colors
- update dynamic color logic for dark mode

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68835eb4dd38832b930a4da3dd114b2a