### PR TITLE
Add base date selection

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,9 @@ const allData = [
 function App() {
   const [query, setQuery] = useState('');
   const [filterType, setFilterType] = useState('');
+  const [baseDate, setBaseDate] = useState(() =>
+    new Date().toISOString().split('T')[0]
+  );
 
   const formatDate = (date) => {
     const yyyy = date.getFullYear();
@@ -97,6 +100,14 @@ function App() {
           />
         </div>
 
+        <input
+          type="date"
+          className="input-style date-input"
+          value={baseDate}
+          onChange={(e) => setBaseDate(e.target.value)}
+          placeholder="기준 날짜 선택"
+        />
+
         <select
           aria-label="카테고리 필터"
           value={filterType}
@@ -138,7 +149,7 @@ function App() {
             } else if (period === 0) {
               message = '즉시 가능';
             } else if (period > 0) {
-              const base = new Date();
+              const base = new Date(baseDate);
               base.setDate(base.getDate() + period);
               message = formatDate(base);
             } else {


### PR DESCRIPTION
## Summary
- allow user to set base date for eligibility calculation
- show date picker under search box
- compute available date from selected base date

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688361c1ee7c832ba8395f7aef3fcf6e