### PR TITLE
Update search behavior and tests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -60,11 +60,13 @@ function App() {
   };
 
   const results = useMemo(() => {
-    // if (!query && !filterType) return [];
     const lower = query.toLowerCase();
     return allData.filter((item) => {
-      if (filterType && item.type !== filterType) return false;
-      if (!query) return true;
+      if (!query) {
+        if (filterType && item.type !== filterType) return false;
+        return true;
+      }
+
       const nameMatch = item.name.toLowerCase().includes(lower);
       const aliasMatch = (item.aliases || []).some((alias) =>
         alias.toLowerCase().includes(lower)
@@ -97,19 +99,21 @@ function App() {
           />
         </div>
 
-        <select
-          aria-label="카테고리 필터"
-          value={filterType}
-          onChange={(e) => setFilterType(e.target.value)}
-          className="input-style w-full max-w-xs"
-        >
-          <option value="">전체</option>
-          <option value="질병">질병</option>
-          <option value="지역">지역</option>
-          <option value="약물">약물</option>
-          <option value="백신">백신</option>
-          <option value="기타">기타</option>
-        </select>
+        {!query && (
+          <select
+            aria-label="카테고리 필터"
+            value={filterType}
+            onChange={(e) => setFilterType(e.target.value)}
+            className="input-style w-full max-w-xs"
+          >
+            <option value="">전체</option>
+            <option value="질병">질병</option>
+            <option value="지역">지역</option>
+            <option value="약물">약물</option>
+            <option value="백신">백신</option>
+            <option value="기타">기타</option>
+          </select>
+        )}
 
 
         <ul className="result-list list-none mt-8 flex flex-col items-center space-y-4">

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -67,3 +67,13 @@ test('카테고리 필터 선택 시 해당 항목이 표시된다', async () =>
   await userEvent.selectOptions(select, '질병');
   expect(screen.getByText('C형 간염')).toBeInTheDocument();
 });
+
+test('검색어 입력 시 필터가 숨겨지고 전체 검색이 수행된다', async () => {
+  render(<App />);
+  const select = screen.getByLabelText(/카테고리 필터/i);
+  await userEvent.selectOptions(select, '질병');
+  const input = screen.getByPlaceholderText(/검색어를 입력하세요/i);
+  await userEvent.type(input, '문신');
+  expect(screen.queryByLabelText(/카테고리 필터/i)).toBeNull();
+  expect(screen.getByText('문신 시술')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- hide category filter when a query is entered
- search across all categories once a query is typed, ignoring previous filter selections
- add test for hiding filter and performing global search

## Testing
- `npm install` *(fails: ENOAUDIT blocked: registry.npmjs.org)*
- `npm test` *(fails: react-scripts not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688361c0d1f0832b867174e66dad0129