### PR TITLE
Add MUI theme toggling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,8 @@ import {
   InputLabel,
   IconButton,
 } from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
+import { lightTheme, darkTheme } from './theme';
 import diseaseData from './data/disease.json';
 import regionData from './data/region.json';
 import medicationData from './data/medication.json';
@@ -88,6 +90,7 @@ function App() {
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      <ThemeProvider theme={theme === 'light' ? lightTheme : darkTheme}>
       <div className="App relative text-center p-8 space-y-6 max-w-3xl mx-auto">
         <h1 className="text-2xl font-bold">헌혈 제한 조건 검색</h1>
 
@@ -188,6 +191,7 @@ function App() {
           )}
         </ul>
       </div>
+      </ThemeProvider>
     </ThemeContext.Provider>
   );
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,13 @@
+import { createTheme } from '@mui/material/styles';
+
+export const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+  },
+});
+
+export const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+  },
+});


### PR DESCRIPTION
## Summary
- create Material UI light/dark theme objects
- wrap App with MUI ThemeProvider and integrate existing ThemeContext

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688372acbcd4832b896706b8aa1c5e6d