### PR TITLE
Apply Material 3 theme

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -3,11 +3,33 @@ import { createTheme } from '@mui/material/styles';
 export const lightTheme = createTheme({
   palette: {
     mode: 'light',
+    primary: {
+      main: '#6750a4',
+      contrastText: '#ffffff',
+    },
+    secondary: {
+      main: '#625b71',
+      contrastText: '#ffffff',
+    },
+    background: {
+      default: '#fffbfe',
+      paper: '#fffbfe',
+    },
   },
 });
 
 export const darkTheme = createTheme({
   palette: {
     mode: 'dark',
+    primary: {
+      main: '#d0bcff',
+    },
+    secondary: {
+      main: '#ccc2dc',
+    },
+    background: {
+      default: '#1c1b1f',
+      paper: '#1c1b1f',
+    },
   },
 });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,8 +6,8 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: '#4b5563',
-        secondary: '#f43f5e',
+        primary: '#6750a4',
+        secondary: '#625b71',
       },
       spacing: {
         '128': '32rem',


### PR DESCRIPTION
## Summary
- set Material 3 palettes in MUI theme files
- redefine Tailwind colors to Material 3 values

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883756d34ac832baf2a632fce760eb3