### PR TITLE
Add inline filter buttons

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,11 +2,9 @@ import { useState, useMemo, useEffect, createContext } from 'react';
 import { FiSearch, FiSun, FiMoon } from 'react-icons/fi';
 import {
   TextField,
-  Select as MUISelect,
-  MenuItem,
-  FormControl,
-  InputLabel,
   IconButton,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
 import { ThemeProvider } from '@mui/material/styles';
 import { lightTheme, darkTheme } from './theme';
@@ -102,7 +100,7 @@ function App() {
           {theme === 'light' ? <FiMoon /> : <FiSun />}
         </IconButton>
 
-        <div className="flex justify-center items-center gap-3">
+        <div className="flex flex-wrap justify-center items-center gap-3">
           <FiSearch />
           <TextField
             variant="outlined"
@@ -111,25 +109,26 @@ function App() {
             onChange={(e) => setQuery(e.target.value)}
             size="small"
           />
+          <ToggleButtonGroup
+            exclusive
+            size="small"
+            value={filterType}
+            onChange={(e, newType) => {
+              if (newType !== null) setFilterType(newType);
+            }}
+            aria-label="카테고리 필터"
+            className={query ? 'invisible' : ''}
+          >
+            <ToggleButton value="">전체</ToggleButton>
+            <ToggleButton value="질병">질병</ToggleButton>
+            <ToggleButton value="지역">지역</ToggleButton>
+            <ToggleButton value="약물">약물</ToggleButton>
+            <ToggleButton value="백신">백신</ToggleButton>
+            <ToggleButton value="기타">기타</ToggleButton>
+          </ToggleButtonGroup>
         </div>
 
         <div className="flex justify-center items-center gap-3">
-          <FormControl size="small" className={query ? 'invisible' : ''}>
-            <InputLabel id="filter-label">카테고리</InputLabel>
-            <MUISelect
-              labelId="filter-label"
-              label="카테고리"
-              value={filterType}
-              onChange={(e) => setFilterType(e.target.value)}
-            >
-              <MenuItem value="">전체</MenuItem>
-              <MenuItem value="질병">질병</MenuItem>
-              <MenuItem value="지역">지역</MenuItem>
-              <MenuItem value="약물">약물</MenuItem>
-              <MenuItem value="백신">백신</MenuItem>
-              <MenuItem value="기타">기타</MenuItem>
-            </MUISelect>
-          </FormControl>
           <TextField
             type="date"
             value={baseDate}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -63,17 +63,17 @@ test('테마 토글 버튼 클릭 시 document 클래스가 변경된다', async
 
 test('카테고리 필터 선택 시 해당 항목이 표시된다', async () => {
   render(<App />);
-  const select = screen.getByLabelText(/카테고리 필터/i);
-  await userEvent.selectOptions(select, '질병');
+  const button = screen.getByRole('button', { name: '질병' });
+  await userEvent.click(button);
   expect(screen.getByText('C형 간염')).toBeInTheDocument();
 });
 
 test('검색어 입력 시 필터가 숨겨지고 전체 검색이 수행된다', async () => {
   render(<App />);
-  const select = screen.getByLabelText(/카테고리 필터/i);
-  await userEvent.selectOptions(select, '질병');
+  const toggle = screen.getByRole('button', { name: '질병' });
+  await userEvent.click(toggle);
   const input = screen.getByPlaceholderText(/검색어를 입력하세요/i);
   await userEvent.type(input, '문신');
-  expect(screen.queryByLabelText(/카테고리 필터/i)).toBeNull();
+  expect(screen.getByLabelText(/카테고리 필터/i)).toHaveClass('invisible');
   expect(screen.getByText('문신 시술')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- replace drop-down filter with inline ToggleButtonGroup
- keep base date field on a separate row
- update tests for ToggleButtonGroup behavior

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883756fea58832bb9dfa5b8a4c63a7b