### PR TITLE
Move date field near search bar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -111,6 +111,14 @@ function App() {
             onChange={(e) => setQuery(e.target.value)}
             size="small"
           />
+          <TextField
+            type="date"
+            aria-label="기준 날짜"
+            value={baseDate}
+            onChange={(e) => setBaseDate(e.target.value)}
+            size="small"
+            className="ml-2"
+          />
         </div>
 
         <div className="flex justify-center items-center gap-3">
@@ -121,6 +129,7 @@ function App() {
               label="카테고리"
               value={filterType}
               onChange={(e) => setFilterType(e.target.value)}
+              inputProps={{ 'aria-label': '카테고리 필터' }}
             >
               <MenuItem value="">전체</MenuItem>
               <MenuItem value="질병">질병</MenuItem>
@@ -130,12 +139,6 @@ function App() {
               <MenuItem value="기타">기타</MenuItem>
             </MUISelect>
           </FormControl>
-          <TextField
-            type="date"
-            value={baseDate}
-            onChange={(e) => setBaseDate(e.target.value)}
-            size="small"
-          />
         </div>
 
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -77,3 +77,13 @@ test('검색어 입력 시 필터가 숨겨지고 전체 검색이 수행된다'
   expect(screen.queryByLabelText(/카테고리 필터/i)).toBeNull();
   expect(screen.getByText('문신 시술')).toBeInTheDocument();
 });
+
+test('날짜 입력을 변경하면 계산된 날짜가 표시된다', async () => {
+  render(<App />);
+  const dateInput = screen.getByLabelText(/기준 날짜/i);
+  await userEvent.clear(dateInput);
+  await userEvent.type(dateInput, '2024-01-01');
+  const input = screen.getByPlaceholderText(/검색어를 입력하세요/i);
+  await userEvent.type(input, '코로나19');
+  expect(screen.getByText('2024년01월31일')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- reposition date field next to the search input
- retain filter select but add accessible label
- test computed date after changing base date

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688375743ea0832bb69fcea790017548