### PR TITLE
Update date input layout and tests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -100,42 +100,43 @@ function App() {
           {theme === 'light' ? <FiMoon /> : <FiSun />}
         </IconButton>
 
-        <div className="flex flex-wrap justify-center items-center gap-3">
-          <FiSearch />
-          <TextField
-            variant="outlined"
-            placeholder="검색어를 입력하세요"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            size="small"
-          />
-          <ToggleButtonGroup
-            exclusive
-            size="small"
-            value={filterType}
-            onChange={(e, newType) => {
-              if (newType !== null) setFilterType(newType);
-            }}
-            aria-label="카테고리 필터"
-            className={query ? 'invisible' : ''}
-          >
-            <ToggleButton value="">전체</ToggleButton>
-            <ToggleButton value="질병">질병</ToggleButton>
-            <ToggleButton value="지역">지역</ToggleButton>
-            <ToggleButton value="약물">약물</ToggleButton>
-            <ToggleButton value="백신">백신</ToggleButton>
-            <ToggleButton value="기타">기타</ToggleButton>
-          </ToggleButtonGroup>
-        </div>
-
-        <div className="flex justify-center items-center gap-3">
+        <div className="flex flex-col sm:flex-row justify-between items-center gap-3">
+          <div className="flex items-center gap-3">
+            <FiSearch />
+            <TextField
+              variant="outlined"
+              placeholder="검색어를 입력하세요"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              size="small"
+            />
+          </div>
           <TextField
             type="date"
             value={baseDate}
             onChange={(e) => setBaseDate(e.target.value)}
             size="small"
+            inputProps={{ 'aria-label': '기준 날짜' }}
           />
         </div>
+
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={filterType}
+          onChange={(e, newType) => {
+            if (newType !== null) setFilterType(newType);
+          }}
+          aria-label="카테고리 필터"
+          className={query ? 'invisible mt-3 sm:mt-0' : 'mt-3 sm:mt-0'}
+        >
+          <ToggleButton value="">전체</ToggleButton>
+          <ToggleButton value="질병">질병</ToggleButton>
+          <ToggleButton value="지역">지역</ToggleButton>
+          <ToggleButton value="약물">약물</ToggleButton>
+          <ToggleButton value="백신">백신</ToggleButton>
+          <ToggleButton value="기타">기타</ToggleButton>
+        </ToggleButtonGroup>
 
 
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -77,3 +77,13 @@ test('검색어 입력 시 필터가 숨겨지고 전체 검색이 수행된다'
   expect(screen.getByLabelText(/카테고리 필터/i)).toHaveClass('invisible');
   expect(screen.getByText('문신 시술')).toBeInTheDocument();
 });
+
+test('기준 날짜 변경 시 결과 날짜가 업데이트된다', async () => {
+  render(<App />);
+  const dateInput = screen.getByLabelText('기준 날짜');
+  await userEvent.clear(dateInput);
+  await userEvent.type(dateInput, '2024-01-01');
+  const input = screen.getByPlaceholderText(/검색어를 입력하세요/i);
+  await userEvent.type(input, '문신');
+  expect(screen.getByText('2024년12월31일')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- reposition date input next to search field
- apply minor style tweaks for spacing
- verify date calculation when changing the base date

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688376a4e9c4832b81f1314a755d483c