### PR TITLE
Refactor result item layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -188,9 +188,14 @@ function App() {
               : 'text-green-500 dark:text-green-400';
 
             return (
-              <li key={item.id} className="result-item">
-                <strong>{item.name}</strong> ({item.type}) - {item.restriction}
-                <div className="period-text">{periodText}</div>
+              <li
+                key={item.id}
+                className="result-item flex flex-col sm:flex-row sm:justify-between"
+              >
+                <div>
+                  <strong>{item.name}</strong> ({item.type}) - {item.restriction}
+                  <div className="period-text">{periodText}</div>
+                </div>
                 <div className={`eligible-date ${colorClass}`}>{message}</div>
               </li>
             );

--- a/src/index.css
+++ b/src/index.css
@@ -18,7 +18,7 @@ html.dark {
 
 .result-item {
   /* Material Design 3 스타일 카드 */
-  @apply bg-[#f4eff4] dark:bg-[#1c1b1f] dark:shadow-md p-4 rounded-lg w-full max-w-2xl mx-auto text-left;
+  @apply bg-[#f4eff4] dark:bg-[#1c1b1f] dark:shadow-md p-4 rounded-lg w-full max-w-2xl mx-auto text-left flex flex-col sm:flex-row sm:items-center sm:justify-between;
 }
 .no-result {
   @apply text-red-500 p-4;
@@ -28,5 +28,5 @@ html.dark {
   @apply text-sm text-gray-700 dark:text-gray-200;
 }
 .eligible-date {
-  @apply text-sm;
+  @apply text-sm sm:text-right;
 }


### PR DESCRIPTION
## Summary
- align result list items with flexbox layout
- allow eligible date text to right align on large screens

## Testing
- `npm install` *(fails: unable to access npm registry)*
- `npm test` *(fails: unable to access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_688394ebb348832ba17690ad6ac12a19